### PR TITLE
Disable "save" button when inputs are blank, add enter key and error msg

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -34,7 +34,7 @@ body {
 }
 
 .form-item {
-  margin-bottom: 10px;
+  margin: 5px;
   padding-left: 5px;
 }
 
@@ -146,6 +146,19 @@ button:focus {
   height: 25px;
   vertical-align: middle;
   padding-bottom: 5px;
+}
+
+.error-msg {
+  opacity: 0;
+  font-size: 14px;
+  width: 90%;
+  /*color: white;*/
+  /*text-shadow: black -1px 1px .5px;*/
+  text-align: center;
+  padding: 5px 0;
+  margin: 0 auto;
+  /*background-color: #ff1744;*/
+  border-radius: 5px;
 }
 
 @media screen and (max-width: 500px){

--- a/index.html
+++ b/index.html
@@ -13,8 +13,9 @@
     <section class="top-section">
       <h1 class="title"><span class="title-idea">idea</span><span class="title-box">box</span></h1>
       <section class="form-section">
-        <input class="text-input form-item title-field" type="text" name="Title" value="" placeholder="Title">
-        <input class="text-input form-item body-field" type="text" name="Body" value="" placeholder="Body">
+        <input class="text-input form-item title-field" type="text" name="Title" placeholder="Title">
+        <input class="text-input form-item body-field" type="text" name="Body" placeholder="Body">
+        <p class="form-item error-msg">Input field(s) are blank!</p>
         <button class="save-button form-item" type="button" name="save-button">save</button>
       </section>
     </section>

--- a/scripts/idea-box.js
+++ b/scripts/idea-box.js
@@ -29,7 +29,7 @@ saveButton.on('click', function () {
 function addCardToList(title, body) {
   var quality = qualityArray[0];
   var newCard =
-    `<article class="card">
+    `<article class="card" id="card-${count}">
       <h2 class="card-title">${title}</h2>
       <input class="card-button delete" type="button" name="name" value="">
       <p class="card-body">${body}</p>
@@ -38,6 +38,7 @@ function addCardToList(title, body) {
       <div class="card-quality">quality: <span class="quality-value">${quality}</span></div>
     </article>`;
   ideaList.prepend(newCard);
+  count++;
 }
 
 function clearInput() {

--- a/scripts/idea-box.js
+++ b/scripts/idea-box.js
@@ -79,6 +79,30 @@ function changeQuality(qualityString, direction) {
   }
 
   return qualityArray[newQualityIndex];
-
-
 }
+
+inputFields.on('blur keypress', function () {
+
+  var titleString = $('.title-field').val();
+  var bodyString = $('.body-field').val();
+  var titleEmpty = stringIsEmpty(titleString);
+  var bodyEmpty = stringIsEmpty(bodyString);
+
+  if (bodyEmpty || titleEmpty) {
+    saveButton.attr('disabled', true);
+  } else if (!bodyEmpty && !titleEmpty) {
+    //hideError();
+    saveButton.attr('disabled', false);
+  }
+});
+
+function stringIsEmpty(string) {
+  return string.length === 0 || (/^(\s)*$/g).test(string);
+}
+
+// click the create-button when user hits enter key
+inputFields.keypress(function(event){
+  if (event.which == 13) {
+    saveButton.click();
+  }
+});

--- a/scripts/idea-box.js
+++ b/scripts/idea-box.js
@@ -8,8 +8,11 @@ var inputFields = $('.title-field, .body-field');
 var ideaList = $('.idea-list');
 var saveButton = $('.save-button');
 var searchField = $('.search-bar');
+var errorMsg = $('.error-msg');
+
 
 titleField.focus();
+saveButton.attr('disabled', true);
 
 function Idea() {
   this.id = id;
@@ -29,14 +32,14 @@ saveButton.on('click', function () {
 function addCardToList(title, body) {
   var quality = qualityArray[0];
   var newCard =
-    `<article class="card" id="card-${count}">
+    $(`<article class="card" id="card-${count}">
       <h2 class="card-title">${title}</h2>
       <input class="card-button delete" type="button" name="name" value="">
       <p class="card-body">${body}</p>
       <input class="card-button upvote" type="button" name="name" value="">
       <input class="card-button downvote" type="button" name="name" value="">
       <div class="card-quality">quality: <span class="quality-value">${quality}</span></div>
-    </article>`;
+    </article>`).hide().fadeIn('normal');
   ideaList.prepend(newCard);
   count++;
 }
@@ -47,7 +50,9 @@ function clearInput() {
 }
 
 ideaList.on('click', '.delete', function () {
-  $(this).parent().remove();
+  $(this).parent().fadeOut('normal', function () {
+    $(this).remove();
+  });
 });
 
 ideaList.on('click', '.upvote', function () {
@@ -85,15 +90,8 @@ inputFields.on('blur keypress', function () {
 
   var titleString = $('.title-field').val();
   var bodyString = $('.body-field').val();
-  var titleEmpty = stringIsEmpty(titleString);
-  var bodyEmpty = stringIsEmpty(bodyString);
+  updateSaveButtonStatus(titleString, bodyString);
 
-  if (bodyEmpty || titleEmpty) {
-    saveButton.attr('disabled', true);
-  } else if (!bodyEmpty && !titleEmpty) {
-    //hideError();
-    saveButton.attr('disabled', false);
-  }
 });
 
 function stringIsEmpty(string) {
@@ -103,6 +101,33 @@ function stringIsEmpty(string) {
 // click the create-button when user hits enter key
 inputFields.keypress(function(event){
   if (event.which == 13) {
-    saveButton.click();
+    if (saveButton.attr('disabled')) {
+      displayError();
+    } else {
+      saveButton.click();
+    }
   }
 });
+
+
+function updateSaveButtonStatus(titleString, bodyString) {
+  var titleEmpty = stringIsEmpty(titleString);
+  var bodyEmpty = stringIsEmpty(bodyString);
+
+  if (bodyEmpty || titleEmpty) {
+    saveButton.attr('disabled', true);
+  } else if (!bodyEmpty && !titleEmpty) {
+    hideError();
+    saveButton.attr('disabled', false);
+  }
+}
+
+function displayError() {
+  errorMsg.css('opacity', '.75');
+  errorMsg.css('transition-duration', '.5s');
+};
+
+function hideError() {
+  errorMsg.css('opacity', '0');
+  errorMsg.css('transition-duration', '.5s');
+};


### PR DESCRIPTION
Added unique id using counter to each new card's HTML, we'll need to fix the counter so it doesn't reset to 0 on page reload after implementing localStorage functionality. Also disabled "save" button until forms are blank, and added enter key functionality with a error message when the enter key is press and one or both of the input forms are empty or just whitespace. TODO: standarize the error message to display when "save" is click and enter key is pressed on blank form, or not display the error message on either and just prevent a new Idea from being constructed/added to the page.
